### PR TITLE
fix: /learn url

### DIFF
--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -40,13 +40,31 @@ export default class Nav extends React.Component {
               role="menu"
             >
               <li className="nav-learn" role="menuitem">
-                <a href="https://learn.freecodecamp.org/" target="_blank" rel="noopener noreferrer">Learn</a>
+                <a
+                  href="https://www.freecodecamp.org/learn/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Learn
+                </a>
               </li>
               <li className="nav-forum" role="menuitem">
-                <a href="https://www.freecodecamp.org/forum/" target="_blank" rel="noopener noreferrer">Forum</a>
+                <a
+                  href="https://www.freecodecamp.org/forum/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Forum
+                </a>
               </li>
               <li className="nav-news nav-current" role="menuitem">
-                <a href="https://www.freecodecamp.org/news/" target="_blank" rel="noopener noreferrer">News</a>
+                <a
+                  href="https://www.freecodecamp.org/news/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  News
+                </a>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
Changes
```
https://learn.freecodecamp.org/
```
to
```
https://www.freecodecamp.org/learn/
```
---
I just noticed the incorrect link in the code, but I'm not sure if this fix is needed since user will get a 301 redirect anyway.