### PR TITLE
chore: use react-hotkeys to handle keyboard shortcuts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2788,7 +2788,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -2806,11 +2807,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2823,15 +2826,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -2934,7 +2940,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -2944,6 +2951,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -2956,17 +2964,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -2983,6 +2994,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3055,7 +3067,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3065,6 +3078,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3140,7 +3154,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3170,6 +3185,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3187,6 +3203,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3225,11 +3242,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -6657,7 +6676,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -6675,11 +6695,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6692,15 +6714,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -6803,7 +6828,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -6813,6 +6839,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -6825,17 +6852,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -6852,6 +6882,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -6924,7 +6955,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -6934,6 +6966,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7009,7 +7042,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7039,6 +7073,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7056,6 +7091,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7094,11 +7130,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         }
@@ -10093,6 +10131,14 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.6.tgz",
       "integrity": "sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q=="
+    },
+    "react-hotkeys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-hotkeys/-/react-hotkeys-2.0.0.tgz",
+      "integrity": "sha512-3n3OU8vLX/pfcJrR3xJ1zlww6KS1kEJt0Whxc4FiGV+MJrQ1mYSYI3qS/11d2MJDFm8IhOXMTFQirfu6AVOF6Q==",
+      "requires": {
+        "prop-types": "^15.6.1"
+      }
     },
     "react-is": {
       "version": "16.8.6",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "react": "^16.8.6",
     "react-device-detect": "^1.7.5",
     "react-dom": "^16.8.6",
+    "react-hotkeys": "^2.0.0",
     "react-scripts": "3.0.1"
   },
   "scripts": {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,6 @@
 import React from "react";
 import NchanSubscriber from "nchan";
+import { GlobalHotKeys } from "react-hotkeys";
 
 import Nav from "./Nav";
 import Main from "./Main";
@@ -7,7 +8,7 @@ import Footer from "./Footer";
 
 import "../css/App.css";
 
-var SUB = new NchanSubscriber(
+const SUB = new NchanSubscriber(
   "wss://coderadio-admin.freecodecamp.org/api/live/nowplaying/coderadio"
 );
 
@@ -70,7 +71,21 @@ export default class App extends React.Component {
       songDuration: 0,
       listeners: 0
     };
-    this.keyboardControl = this.keyboardControl.bind(this);
+
+    // Keyboard shortcuts
+    this.keyMap = {
+      TOGGLE_PLAY: ["space", "k"],
+      INCREASE_VOLUME: "up",
+      DECREASE_VOLUME: "down"
+    };
+
+    // Keyboard shortcut handlers
+    this.handlers = {
+      TOGGLE_PLAY: () => this.togglePlay(),
+      INCREASE_VOLUME: () => this.increaseVolume(),
+      DECREASE_VOLUME: () => this.decreaseVolume()
+    };
+
     this.togglePlay = this.togglePlay.bind(this);
     this.setUrl = this.setUrl.bind(this);
     this.setTargetVolume = this.setTargetVolume.bind(this);
@@ -85,7 +100,6 @@ export default class App extends React.Component {
   componentDidMount() {
     this.setPlayerInitial();
     this.getNowPlaying();
-    window.addEventListener('keydown', this.keyboardControl, false);
   }
 
   /** *
@@ -298,63 +312,51 @@ export default class App extends React.Component {
     SUB.start();
   }
 
-  // keyboard shortcuts
-  keyboardControl = evt => {
-    switch (evt.key) {
-      case " ":
-      case "k":
-        this.togglePlay();
-        break;
-      case "ArrowUp":
-        this.setTargetVolume(
-          Math.min(
-            this.state.audioConfig.maxVolume +
-              this.state.audioConfig.volumeSteps,
-            1
-          )
-        );
+  increaseVolume = () =>
+    this.setTargetVolume(
+      Math.min(
+        this.state.audioConfig.maxVolume + this.state.audioConfig.volumeSteps,
+        1
+      )
+    );
 
-        break;
-      case "ArrowDown":
-        this.setTargetVolume(
-          Math.max(
-            this.state.audioConfig.maxVolume -
-              this.state.audioConfig.volumeSteps,
-            0
-          )
-        );
-        break;
-      default:
-    }
-  };
+  decreaseVolume = () =>
+    this.setTargetVolume(
+      Math.max(
+        this.state.audioConfig.maxVolume - this.state.audioConfig.volumeSteps,
+        0
+      )
+    );
 
   render() {
     return (
-      <div className="App" tabIndex="0">
-        <Nav />
-        <Main
-          fastConnection={this.state.fastConnection}
-          player={this._player}
-          playing={this.state.playing}
-        />
-        <audio crossOrigin="anonymous" ref={a => (this._player = a)} />
-        <Footer
-          currentSong={this.state.currentSong}
-          currentVolume={this.state.audioConfig.currentVolume}
-          fastConnection={this.state.fastConnection}
-          listeners={this.state.listeners}
-          mounts={this.state.mounts}
-          player={this._player}
-          playing={this.state.playing}
-          remotes={this.state.remotes}
-          setTargetVolume={this.setTargetVolume}
-          setUrl={this.setUrl}
-          songDuration={this.state.songDuration}
-          songStartedAt={this.state.songStartedAt}
-          togglePlay={this.togglePlay}
-          url={this.state.url}
-        />
-      </div>
+      <GlobalHotKeys handlers={this.handlers} keyMap={this.keyMap}>
+        <div className="App" tabIndex="0">
+          <Nav />
+          <Main
+            fastConnection={this.state.fastConnection}
+            player={this._player}
+            playing={this.state.playing}
+          />
+          <audio crossOrigin="anonymous" ref={a => (this._player = a)} />
+          <Footer
+            currentSong={this.state.currentSong}
+            currentVolume={this.state.audioConfig.currentVolume}
+            fastConnection={this.state.fastConnection}
+            listeners={this.state.listeners}
+            mounts={this.state.mounts}
+            player={this._player}
+            playing={this.state.playing}
+            remotes={this.state.remotes}
+            setTargetVolume={this.setTargetVolume}
+            setUrl={this.setUrl}
+            songDuration={this.state.songDuration}
+            songStartedAt={this.state.songStartedAt}
+            togglePlay={this.togglePlay}
+            url={this.state.url}
+          />
+        </div>
+      </GlobalHotKeys>
     );
   }
 }


### PR DESCRIPTION
This PR:
- Replaces `addEventListener` call with `react-hotkeys` library
- Moves the handlers of ArrowUp and ArrowDown keys to their own stand-alone function
- Closes #64 

**Note**: I use [GlobalHotKeys component](https://github.com/greena13/react-hotkeys#globalhotkeys-component) instead of `HotKeys` to achieve the behavior introduced in #58