### PR TITLE
chore: make the app container unfocusable

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -377,7 +377,7 @@ export default class App extends React.Component {
   render() {
     return (
       <GlobalHotKeys handlers={this.handlers} keyMap={this.keyMap}>
-        <div className="App" tabIndex="0">
+        <div className="App">
           <Nav />
           <Main
             fastConnection={this.state.fastConnection}


### PR DESCRIPTION
I believe we initially made the app container focusable in order to have keyboard shortcuts working properly. Now that we have replaced manual keyboard event handling with `react-hotkeys`, there is no need to make the container focusable any more.

This PR cleans that up and resolves #74 in the process.