### PR TITLE
chore: remove unused prop

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -407,7 +407,6 @@ export default class App extends React.Component {
             fastConnection={this.state.fastConnection}
             listeners={this.state.listeners}
             mounts={this.state.mounts}
-            player={this._player}
             playing={this.state.playing}
             remotes={this.state.remotes}
             setTargetVolume={this.setTargetVolume}

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -95,7 +95,6 @@ Footer.propTypes = {
   fastConnection: PropTypes.bool,
   listeners: PropTypes.number,
   mounts: PropTypes.array,
-  player: PropTypes.object,
   playing: PropTypes.bool,
   remotes: PropTypes.array,
   setTargetVolume: PropTypes.func,


### PR DESCRIPTION
Removes the `player` prop that is being passed to the Footer component, but isn't used.