### PR TITLE
fix: prevent the app from autoplaying the music

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -109,12 +109,20 @@ export default class App extends React.Component {
    * resets the URL.
    */
   setUrl(url = false) {
-    if (url) {
-      if (this.state.playing) this.pause();
-      this._player.src = url;
-      this.setState({
-        url
-      });
+    if (!url) return;
+
+    if (this.state.playing) this.pause();
+
+    this._player.src = url;
+    this.setState({
+      url
+    });
+
+    // Since the `playing` state is initially `null` when the app first loads
+    // and is set to boolean when there is an user interaction,
+    // we prevent the app from auto-playing the music
+    // by only calling `this.play()` if the `playing` state is not `null`
+    if (this.state.playing !== null) {
       this.play();
     }
   }


### PR DESCRIPTION
This PR is an attempt to prevent #81 from happening again.

### My theory

Quoted from [my comment](https://github.com/freeCodeCamp/coderadio-client/issues/81#issuecomment-654034487) in the issue thread:
> - OP lands on the page
> - The first stream URL they got had certificate issue (#79)
> - The page switches to a new stream and tries to play it
> - Since OP didn't interact with the page, the browser blocks the audio from playing

### The exact cause
When user lands on the page, we make a websocket call to get all the stream URLs. The streams then get sorted and the first one in the list is set to the audio source. I'm not sure if this is true, but I guess the browser tries to load the media source (without actually playing it), and if it fails, it will call the `onError`.

In the error handling function, we do some logic to get a new array of streams, then pick the first one and call `setUrl()` with it (https://github.com/freeCodeCamp/coderadio-client/blob/master/src/components/App.js#L380). The problem is, inside `setUrl()`, we call `this.play()` after the new URL is set. Since the browsers don't allow media from being played without user interaction, we have an error here.

### The fix

The fix for this is to have a null check before calling `this.play()` in `setUrl()`, as `this.playing.state` is initially `null` when the app has no user interaction.

### Testing

To test the change, I used the Privacy Badger extension (https://privacybadger.org/) to block our streams:

<img width="429" alt="Screen Shot 2020-07-20 at 11 13 52 PM" src="https://user-images.githubusercontent.com/25715018/87963341-c1bc8a80-cae2-11ea-8be9-f0ec4bf228c0.png">

The expect behaviors are:
- When user enters the page and the first URL is not available, the app should set a new URL **without** automatically playing it
- When user is listening to the music and the stream stops working, the app should set a new URL then automatically plays the music
- When user changes the music source using the dropdown, the app should set the URL and automatically plays the music
