### PR TITLE
chore: rearrange menu items

### DIFF
--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -39,31 +39,31 @@ export default class Nav extends React.Component {
               id="nav"
               role="menu"
             >
-              <li className="nav-learn" role="menuitem">
+              <li className="nav-news nav-current" role="menuitem">
                 <a
-                  href="https://www.freecodecamp.org/learn/"
-                  target="_blank"
+                  href="https://www.freecodecamp.org/news/"
                   rel="noopener noreferrer"
+                  target="_blank"
                 >
-                  Learn
+                  News
                 </a>
               </li>
               <li className="nav-forum" role="menuitem">
                 <a
                   href="https://www.freecodecamp.org/forum/"
-                  target="_blank"
                   rel="noopener noreferrer"
+                  target="_blank"
                 >
                   Forum
                 </a>
               </li>
-              <li className="nav-news nav-current" role="menuitem">
+              <li className="nav-learn" role="menuitem">
                 <a
-                  href="https://www.freecodecamp.org/news/"
-                  target="_blank"
+                  href="https://www.freecodecamp.org/learn/"
                   rel="noopener noreferrer"
+                  target="_blank"
                 >
-                  News
+                  Learn
                 </a>
               </li>
             </ul>


### PR DESCRIPTION
Changes the order of navigation menu items, to make it consistent with the order on the main FCC page, and benefit those who navigate between FCC pages with muscle memory 😄 

Before

<img width="1680" alt="Screen Shot 2020-07-24 at 11 21 06 PM" src="https://user-images.githubusercontent.com/25715018/88412846-62bd8500-ce04-11ea-96e8-7c91cbc6c835.png">

After

<img width="1680" alt="Screen Shot 2020-07-24 at 11 12 45 PM" src="https://user-images.githubusercontent.com/25715018/88412775-47527a00-ce04-11ea-90a9-c32448064237.png">
