### PR TITLE
feat: Save user volume to local storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11315,6 +11315,11 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
+    "store": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/store/-/store-2.0.12.tgz",
+      "integrity": "sha1-jFNOKguDH3K3X8XxEZhXxE711ZM="
+    },
     "stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "react-device-detect": "^1.7.5",
     "react-dom": "^16.8.6",
     "react-hotkeys": "^2.0.0",
-    "react-scripts": "3.0.1"
+    "react-scripts": "3.0.1",
+    "store": "^2.0.12"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,6 +1,7 @@
 import React from "react";
 import NchanSubscriber from "nchan";
 import { GlobalHotKeys } from "react-hotkeys";
+import store from 'store';
 
 import Nav from "./Nav";
 import Main from "./Main";
@@ -15,6 +16,12 @@ const SUB = new NchanSubscriber(
 export default class App extends React.Component {
   constructor(props) {
     super(props);
+    /*
+     * Get user volume level from local storage
+     * if not available set to default 0.5.
+     */
+    this.storageVolume = store.get('coderadio-volume') || 0.5;
+
     this.state = {
       /** *
        * General configuration options
@@ -45,9 +52,9 @@ export default class App extends React.Component {
       // (Used in earlier projects and just maintained)
       audioConfig: {
         targetVolume: 0,
-        maxVolume: 0.5,
+        maxVolume: this.storageVolume,
         volumeSteps: 0.1,
-        currentVolume: 0.5,
+        currentVolume: this.storageVolume,
         volumeTransitionSpeed: 100
       },
 
@@ -179,6 +186,9 @@ export default class App extends React.Component {
     this._player.volume = audioConfig.maxVolume;
     this.setState({
       audioConfig
+    }, () => {
+       // Save user volume to local storage
+      store.set('coderadio-volume', maxVolume)
     });
   }
 


### PR DESCRIPTION
Hi! I've tried adding this feature before but didn't complete the requirements for it to be merged... Hope this time I get it right. I would really like if the radio-client remembered my volume preference xD

If something is not correct or complete, just tell me and I'll correct it.