### PR TITLE
fix: prevent the SUB.stop() call if the audio is already paused

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -190,6 +190,8 @@ export default class App extends React.Component {
   }
 
   pause() {
+    if (this._player.paused) return;
+
     // completely stop the audio element
     this._player.src = "";
     this._player.pause();


### PR DESCRIPTION
I sometimes encounter the following error when toggling play/pause too fast. My fix for it is to add a condition to ensure `SUB.stop()` will not be called if the audio is already being paused.

(This screen can only be seen in local environment, but the error does get logged in the console in production)

<img width="1680" alt="Screen Shot 2020-11-18 at 12 03 38 AM" src="https://user-images.githubusercontent.com/25715018/99422642-5371c280-2932-11eb-83b2-8f5a60ce4892.png">
