### PR TITLE
fix: Handle Volume 0 error

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -141,6 +141,11 @@ export default class App extends React.Component {
   play() {
     const { mounts, remotes } = this.state;
     if (this._player.paused) {
+      // Catch if volume was set to 0 by user
+      // If so, return early to avoid play/pause loop error
+      if (this.state.audioConfig.maxVolume === 0) {
+        return;
+      }
       if (!SUB.running) {
         SUB.start();
       }
@@ -150,7 +155,7 @@ export default class App extends React.Component {
         stream => stream.url
       );
 
-      // check if the url has been reseted by pause
+      // check if the url has been reset by pause
       if (!streamUrls.includes(this._player.src)) {
         this._player.src = this.state.url;
         this._player.load();


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

This is a bit of an edge case here, and is likely unrelated to the issues in #80, but I discovered this when attempting to reproduce that error.

If a user sets their volume to 0 and pauses the stream, hitting the play button throws errors. On a local dev instance, this crashes the app - in production, it throws a bunch of errors. This does *not* happen when the `fade` feature sets the volume to 0, because it's specifically based on the `maxVolume` value. 

I've added a condition to the `play()` function to return immediately if the `audioConfig.maxVolume` value is at 0 - with this change, the play button still does nothing if the user sets the volume to 0 manually, but we are not throwing uncaught errors anymore.

If we don't want this to silently fail, I could leverage an alert or a custom banner to inform the user to set the volume to more than 0 before pressing play, but IMHO this is enough of an edge case that it's not warranted.