### PR TITLE
fix: Revert sentry error logging

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -381,10 +381,7 @@ export default class App extends React.Component {
       )
     );
 
-  onPlayerError = err => {
-    // NOTE: this might be a bit noisy, so we should monitor it before promoting
-    // coderadio
-    Sentry.captureException(err);
+  onPlayerError = () => {
     /*
      * This error handler works as follows:
      * - When the player cannot play the url:


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Pulls the Sentry error logging out of the `onPlayerError` method - this was generating a lot of noise and resulting in 429 rate limits.

With this change, we should be able to re-enable the sentry setup on production and listen specifically for errors within the `NchanSubscriber` itself.