### PR TITLE
fix: Android initial play error

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -339,7 +339,7 @@ export default class App extends React.Component {
           mounts: np.station.mounts,
           remotes: np.station.remotes
         });
-        this.setMountToConnection(np.station.mounts);
+        this.setMountToConnection(np.station.mounts, np.station.remotes);
       }
 
       if (this.state.listeners !== np.listeners.current) {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -339,7 +339,7 @@ export default class App extends React.Component {
           mounts: np.station.mounts,
           remotes: np.station.remotes
         });
-        this.setMountToConnection(np.station.mounts, np.station.remotes);
+        this.setMountToConnection(np.station.mounts);
       }
 
       if (this.state.listeners !== np.listeners.current) {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -72,7 +72,6 @@ export default class App extends React.Component {
       playing: null,
       pullMeta: false,
       erroredStreams: [],
-      interacted: false,
 
       // Note: the crossOrigin is needed to fix a CORS JavaScript requirement
 
@@ -157,21 +156,14 @@ export default class App extends React.Component {
         this._player.load();
       }
       this._player.volume = 0;
-      if (!this.state.interacted) {
-        setTimeout(() => {
-          this._player.play();
-        }, 200);
-      } else {
-        this._player.play();
-      }
+      this._player.play()
 
       let audioConfig = this.state.audioConfig;
       audioConfig.currentVolume = 0;
       this.setState({
         audioConfig,
         playing: true,
-        pullMeta: true,
-        interacted: true
+        pullMeta: true
       });
 
       this.fadeUp();

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -156,7 +156,7 @@ export default class App extends React.Component {
         this._player.load();
       }
       this._player.volume = 0;
-      this._player.play()
+      this._player.play();
 
       let audioConfig = this.state.audioConfig;
       audioConfig.currentVolume = 0;

--- a/src/components/PlayPauseButton.js
+++ b/src/components/PlayPauseButton.js
@@ -12,7 +12,7 @@ class PlayPauseButton extends React.Component {
 
   handleOnClick = () => isBrowser && this.props.togglePlay();
 
-  handleOnTouchStart = () => !isBrowser && this.props.togglePlay();
+  handleOnTouchEnd = () => !isBrowser && this.props.togglePlay();
 
   handleKeyDown = e => {
     // Toggle play when user presses Enter
@@ -38,7 +38,7 @@ class PlayPauseButton extends React.Component {
         id="playContainer"
         onClick={this.handleOnClick}
         onKeyDown={this.handleKeyDown}
-        onTouchStart={this.handleOnTouchStart}
+        onTouchEnd={this.handleOnTouchEnd}
         role="button"
         tabIndex={0}
       >


### PR DESCRIPTION
Essentially, the issue on mobile phones was due to a race condition where the event loop that tracked a user's initial page interaction hadn't resolved by the time `play()` was called. I fixed this by leveraging a new prop for `interacted`, which initialises as `false`. When a user clicks the play button, instead of immediately calling `play` I set a 200ms timeout (barely noticeable on the page) to allow that interaction to get logged, eliminating the erroneous "user has not interacted with the page" issue. In that timeout, the `interacted` flips to true and future play calls will run normally.

Closes #97 