### PR TITLE
fix: Replace favicons, use CDN logo

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
       property="og:description"
     />
     <meta
-      content="https://freecodecamp.s3.amazonaws.com/guide-sql-images/code-radio-meta-image.jpg"
+      content="https://cdn.freecodecamp.org/platform/universal/fcc_meta_1920X1080-indigo.png"
       property="og:image"
     />
     <meta content="article" property="og:type" />
@@ -37,7 +37,7 @@
     <meta content="@freecodecamp" name="twitter:site" />
     <meta content="summary_large_image" name="twitter:card" />
     <meta
-      content="https://freecodecamp.s3.amazonaws.com/guide-sql-images/code-radio-meta-image.jpg"
+      content="https://cdn.freecodecamp.org/platform/universal/fcc_meta_1920X1080-indigo.png"
       name="twitter:image:src"
     />
     <meta content="Code Radio" name="twitter:title" />
@@ -47,141 +47,43 @@
     />
     <meta content="a40ee5d5dba3bb091ad783ebd2b1383f" name="p:domain_verify" />
     <meta content="#FFFFFF" name="msapplication-TileColor" />
-    <meta content="/" name="msapplication-TileImage" />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/android-chrome-144x144.png"
-      rel="android-chrome"
-      sizes="144x144"
+    <meta
+      content="https://cdn.freecodecamp.org/universal/favicons/browserconfig.xml"
+      rel="msapplication-config"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/android-chrome-192x192.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/android-chrome-192x192.png"
       rel="android-chrome"
       sizes="192x192"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/android-chrome-36x36.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/android-chrome-384x384.png"
       rel="android-chrome"
-      sizes="36x36"
+      sizes="384x384"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/android-chrome-48x48.png"
-      rel="android-chrome"
-      sizes="48x48"
+      href="https://cdn.freecodecamp.org/universal/favicons/site.webmanifest"
+      rel="manifest"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/android-chrome-72x72.png"
-      rel="android-chrome"
-      sizes="72x72"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/android-chrome-96x96.png"
-      rel="android-chrome"
-      sizes="96x96"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/android-chrome-manifest.json"
-      rel="android-chrome-manifest"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-114x114.png"
-      rel="apple-touch-icon"
-      sizes="114x114"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-120x120.png"
-      rel="apple-touch-icon"
-      sizes="120x120"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-144x144.png"
-      rel="apple-touch-icon"
-      sizes="144x144"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-152x152.png"
-      rel="apple-touch-icon"
-      sizes="152x152"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-180x180.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
       rel="apple-touch-icon"
       sizes="180x180"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-57x57.png"
-      rel="apple-touch-icon"
-      sizes="57x57"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-60x60.png"
-      rel="apple-touch-icon"
-      sizes="60x60"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-72x72.png"
-      rel="apple-touch-icon"
-      sizes="72x72"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-76x76.png"
-      rel="apple-touch-icon"
-      sizes="76x76"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-precomposed.png"
-      rel="apple-touch-icon-precomposed"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon.png"
-      rel="apple-touch-icon"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/favicon-16x16.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/favicon-16x16.png"
       rel="favicon"
       sizes="16x16"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/favicon-32x32.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/favicon-32x32.png"
       rel="favicon"
       sizes="32x32"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/favicon-96x96.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/favicon-32x32.png"
       rel="favicon"
       sizes="96x96"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/mstile-144x144.png"
-      rel="mstile"
-      sizes="144x144"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/mstile-150x150.png"
-      rel="mstile"
-      sizes="150x150"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/mstile-310x310.png"
-      rel="mstile"
-      sizes="310x310"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/mstile-310x150.png"
-      rel="mstile"
-      sizes="310x150"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/mstile-70x70.png"
-      rel="mstile"
-      sizes="70x70"
-    />
-    <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/favicon.ico"
-      rel="favicon"
-    />
-    <link
-      href="//s3.amazonaws.com/freecodecamp/favicons/favicon.ico"
-      rel="shortcut icon"
     />
     <title>freeCodeCamp.org Code Radio</title>
     <script

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -29,7 +29,7 @@ export default function Nav() {
         >
           <img
             alt="Code Radio"
-            src="https://cdn-media-1.freecodecamp.org/code-radio/FCC-logo.png"
+            src="https://cdn.freecodecamp.org/platform/universal/fcc_primary.svg"
           />
         </a>
       </div>


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

This PR replaces the green favicons from the S3 instance with the indigo favicons from the CDN, and uses the CDN-hosted logo for the header.

@ahmadabdolsaheb I don't see a version of the coderadio meta image on the CDN. I used our standard 1920x1080 image, but if we want to maintain the existing unique image let me know. 🙂 

Closes #100 