### PR TITLE
Increase slider max range

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -57,10 +57,10 @@ export default class App extends React.Component {
       // (Used in earlier projects and just maintained)
       audioConfig: {
         targetVolume: 0,
-        maxVolume: 0.5,
-        volumeSteps: 0.1,
-        currentVolume: 0.5,
-        volumeTransitionSpeed: 100
+        maxVolume: 0.50,
+        volumeSteps: 0.01,
+        currentVolume: 0.50,
+        volumeTransitionSpeed: 10
       },
 
       /** *
@@ -224,7 +224,7 @@ export default class App extends React.Component {
 
   setTargetVolume(v) {
     let audioConfig = { ...this.state.audioConfig };
-    let maxVolume = parseFloat(Math.max(0, Math.min(1, v).toFixed(1)));
+    let maxVolume = parseFloat(Math.max(0, Math.min(1, v).toFixed(2)));
     audioConfig.maxVolume = maxVolume;
     audioConfig.currentVolume = maxVolume;
     this._player.volume = audioConfig.maxVolume;
@@ -268,7 +268,7 @@ export default class App extends React.Component {
      *  In order to fix floating math issues,
      *  we set the toFixed in order to avoid 0.999999999999 increments
      */
-    let currentVolume = parseFloat(this._player.volume.toFixed(1));
+    let currentVolume = parseFloat(this._player.volume.toFixed(2));
     // If the volume is correctly set to the target, no need to change it
     if (currentVolume === this.state.audioConfig.targetVolume) {
       // If the audio is set to 0 and it’s been met, pause the audio

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -1,18 +1,21 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+const MAX = 100
+
 const Slider = ({ currentVolume, setTargetVolume }) => {
-  const sliderVal = currentVolume * 10;
   const handleChange = e => {
     let { value } = e.target;
-    setTargetVolume(value / 10);
+    setTargetVolume(value / MAX);
   }
+
+  const sliderVal = currentVolume * MAX;
 
   return (
     <div className="slider-container">
       <input
         id="slider"
-        max="10"
+        max={MAX}
         min="0"
         onChange={handleChange}
         type="range"


### PR DESCRIPTION
~~Hi, I've branched this out from #89 which is branched out from the latest master commit. I hope it's not a problem for you. In both cases, git will do a clean "fast-forward" merge without any conflicts.~~

The feature makes the slider more precise by increasing the range input's max value. I think it's nice when you want to set the volume "really low" without also lowering your system volume, which I find myself doing a lot.