### PR TITLE
fix: Missed default favicon, remove extra size

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -82,7 +82,7 @@
     />
     <link
       href="https://cdn.freecodecamp.org/universal/favicons/favicon.ico"
-      rel="favicon"
+      rel="icon"
     />
     <title>freeCodeCamp.org Code Radio</title>
     <script

--- a/public/index.html
+++ b/public/index.html
@@ -81,9 +81,8 @@
       sizes="32x32"
     />
     <link
-      href="https://cdn.freecodecamp.org/universal/favicons/favicon-32x32.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/favicon.ico"
       rel="favicon"
-      sizes="96x96"
     />
     <title>freeCodeCamp.org Code Radio</title>
     <script


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Adds the missing base favicon file, removes the unneeded 96x96 link.