### PR TITLE
fix: Replace meta image

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
       property="og:description"
     />
     <meta
-      content="https://cdn.freecodecamp.org/platform/universal/fcc_meta_1920X1080-indigo.png"
+      content="https://cdn.freecodecamp.org/coderadio/coderadio-meta-1920x1080.png"
       property="og:image"
     />
     <meta content="article" property="og:type" />
@@ -37,7 +37,7 @@
     <meta content="@freecodecamp" name="twitter:site" />
     <meta content="summary_large_image" name="twitter:card" />
     <meta
-      content="https://cdn.freecodecamp.org/platform/universal/fcc_meta_1920X1080-indigo.png"
+      content="https://cdn.freecodecamp.org/coderadio/coderadio-meta-1920x1080.png"
       name="twitter:image:src"
     />
     <meta content="Code Radio" name="twitter:title" />


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

With https://github.com/freeCodeCamp/cdn/pull/60 merged, we now have a dedicated code radio image in our CDN. This PR changes the meta links to use that image rather than the universal freeCodeCamp image.