### PR TITLE
fix: stream dropdown

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -141,26 +141,22 @@ export default class App extends React.Component {
    * and begin playing it again. This can happen if the server
    * resets the URL.
    */
-  setUrl(url = false) {
+  async setUrl(url = false) {
     if (!url) return;
 
-    const onPause = () => {
-      this._player.src = url;
-      this.setState({ url });
+    if (this.state.playing) await this.pause();
 
-      // Since the `playing` state is initially `null` when the app first loads
-      // and is set to boolean when there is an user interaction,
-      // we prevent the app from auto-playing the music
-      // by only calling `this.play()` if the `playing` state is not `null`
-      if (this.state.playing !== null) {
-        this.play();
-      }
-    }
+    this._player.src = url;
+    this.setState({
+      url
+    });
 
-    if (this.state.playing) {
-      // this.pause() calls setState to update the `playing` state.
-      // We need to pass a callback function to it in order to have the logic executed correctly
-      this.pause(onPause);
+    // Since the `playing` state is initially `null` when the app first loads
+    // and is set to boolean when there is an user interaction,
+    // we prevent the app from auto-playing the music
+    // by only calling `this.play()` if the `playing` state is not `null`
+    if (this.state.playing !== null) {
+      this.play();
     }
   }
 
@@ -187,7 +183,6 @@ export default class App extends React.Component {
           return {
             audioConfig: { ...state.audioConfig, currentVolume: 0 },
             playing: true,
-            pausing: false,
             pullMeta: true
           };
         });
@@ -197,7 +192,7 @@ export default class App extends React.Component {
     }
   }
 
-  pause(callback) {
+  pause() {
     // completely stop the audio element
     if (this.state.playing) {
       this._player.src = '';
@@ -206,9 +201,8 @@ export default class App extends React.Component {
 
       this.setState({
         playing: false,
-        pausing: true,
-      }, callback);
-
+        pausing: false
+      });
       SUB.stop();
     }
   }

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -51,7 +51,7 @@ export default class Footer extends React.Component {
       mountOptions = (
         <select
           data-meta='stream-select'
-          onv={this.handleChange.bind(this)}
+          onChange={this.handleChange.bind(this)}
           value={this.props.url}
         >
           {alternativeMounts.map((mount, index) => (


### PR DESCRIPTION
There is a typo in the onChange event of the footer dropdown, which is causing the selection to not be registered.

Also, the behavior of `setUrl` seems to be odd, in that the player stops completely when I select a stream. I found that this is due to the `playing` state not being updated (to `false`) at the time we execute the set URL logic (which needs `playing` to be `false`). Though I'm not sure why I didn't encounter the issue before

---

## Before

![switch-stream-before](https://user-images.githubusercontent.com/25715018/103436995-9377d500-4c54-11eb-88c6-62b24bfbb791.gif)

## After

![switch-stream-after](https://user-images.githubusercontent.com/25715018/103437056-2e70af00-4c55-11eb-827d-7be96fc3adc5.gif)

