### PR TITLE
feat: make background image responsive

### DIFF
--- a/src/css/App.css
+++ b/src/css/App.css
@@ -197,23 +197,25 @@ footer {
   background-color: white;
 }
 
-.animation {
-  background-image: url('https://cdn-media-1.freecodecamp.org/code-radio/bg.jpg');
-  background-position: left bottom;
-  background-repeat: no-repeat;
-  position: relative;
-  width: 100%;
-  height: calc(100% - 158px);
-}
+@media (min-width: 750px) {
+  .animation {
+    background-image: url('https://cdn-media-1.freecodecamp.org/code-radio/bg.jpg');
+    background-position: left bottom;
+    background-repeat: no-repeat;
+    position: relative;
+    width: 100%;
+    height: calc(100% - 158px);
+  }
 
-.animation.saron::before {
-  content: '';
-  background-image: url('https://cdn-media-1.freecodecamp.org/code-radio/Saron3.gif');
-  left: 388px;
-  bottom: 0px;
-  width: 509px;
-  height: 767px;
-  position: absolute;
+  .animation.saron::before {
+    content: '';
+    background-image: url('https://cdn-media-1.freecodecamp.org/code-radio/Saron3.gif');
+    left: 388px;
+    bottom: 0px;
+    width: 509px;
+    height: 767px;
+    position: absolute;
+  }
 }
 
 details {
@@ -301,6 +303,15 @@ dd {
   }
   #playContainer::before {
     display: none;
+  }
+  .animation {
+    background-image: url('https://cdn-media-1.freecodecamp.org/code-radio/bg.jpg');
+    background-position: left bottom;
+    background-repeat: no-repeat;
+    position: relative;
+    width: 100%;
+    height: calc(100% - 158px);
+    background-size: 100%;
   }
 }
 


### PR DESCRIPTION
Hi,

This PR is for making the background image responsive.
The animation is present for screens with width > 750 px
For screens with width < 750 px, I keep only the background image
For screens with width < 500 px, a blue background is displayed

This PR is for the issue #105