### PR TITLE
fix: use boolean for value of fastConnection

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -36,7 +36,7 @@ export default class App extends React.Component {
       },
       fastConnection: navigator.connection
         ? navigator.connection.downlink > 1.5
-        : null,
+        : false,
 
       /** *
        * The equalizer data is held as a separate data set


### PR DESCRIPTION
Our set stream function checks if `fastConnection` is either true or false, but its initial value can be `null`, therefore failing all the conditions for relays and fall back to use mount.

https://github.com/freeCodeCamp/coderadio-client/blob/9c45fb91382caec49ec759d0162c6658af1e9200/src/components/App.js#L368-L383

Fixes #120 