### PR TITLE
fix: Make background image responsive

### DIFF
--- a/src/css/App.css
+++ b/src/css/App.css
@@ -302,6 +302,9 @@ dd {
   #playContainer::before {
     display: none;
   }
+  #visualizer {
+    background-color: #002ead;
+  }
 }
 
 @media (max-width: 500px) {


### PR DESCRIPTION
Hi,

This PR is for making the background image responsive.
The animation is present for screens with width > 750 px
For screens with width < 750 px, I keep only the background image
For screens with width < 500 px, a blue background is displayed

I am open for any improvement

This PR is for the issue #105

