### PR TITLE
Universal Box Sizing with Inheritance

### DIFF
--- a/src/css/App.css
+++ b/src/css/App.css
@@ -1,6 +1,11 @@
 @import url('https://fonts.googleapis.com/css?family=Lato:400,700&display=swap');
-* {
+ 
+ 
+html {
   box-sizing: border-box;
+}
+*, *:before, *:after {
+  box-sizing: inherit;
   font-family: 'Lato', Arial;
 }
 


### PR DESCRIPTION
This reset gives you more flexibility than its predecessors — you can use content-box or padding-box (where supported) at will, without worrying about a universal selector overriding your CSS.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
