### PR TITLE
fix: play button on mobile

### DIFF
--- a/src/components/PlayPauseButton.js
+++ b/src/components/PlayPauseButton.js
@@ -32,18 +32,16 @@ class PlayPauseButton extends React.Component {
 
   render() {
     return (
-      <div
+      <button
         aria-label={this.props.playing ? 'Pause' : 'Play'}
         className={this.state.initialLoad ? 'cta' : ''}
         id='playContainer'
         onClick={this.handleOnClick}
         onKeyDown={this.handleKeyDown}
         onTouchEnd={this.handleOnTouchEnd}
-        role='button'
-        tabIndex={0}
       >
         {this.props.playing ? <Pause /> : <Play />}
-      </div>
+      </button>
     );
   }
 }

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -93,6 +93,9 @@ footer {
   padding: 15px;
   cursor: pointer;
   position: relative;
+  background-color: transparent;
+  color: #ffffff;
+  border: none;
 }
 
 #playContainer::before {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

This PR is an attempt to fix the issue with the play button on mobile, specifically iOS devices. The fix is to convert the div that has `role="button"` to a `button` tag. 

I don't have an iOS device to test if my change addresses the issue, and could only ensure that there is no regression caused by the change.

Ref https://github.com/freeCodeCamp/freeCodeCamp/issues/41070
