### PR TITLE
fix: use onTouchStart event in PlayPauseButton

### DIFF
--- a/src/components/PlayPauseButton.js
+++ b/src/components/PlayPauseButton.js
@@ -12,7 +12,7 @@ class PlayPauseButton extends React.Component {
 
   handleOnClick = () => isBrowser && this.props.togglePlay();
 
-  handleOnTouchEnd = () => !isBrowser && this.props.togglePlay();
+  handleOnTouchStart = () => !isBrowser && this.props.togglePlay();
 
   handleKeyDown = e => {
     // Toggle play when user presses Enter
@@ -38,7 +38,7 @@ class PlayPauseButton extends React.Component {
         id='playContainer'
         onClick={this.handleOnClick}
         onKeyDown={this.handleKeyDown}
-        onTouchEnd={this.handleOnTouchEnd}
+        onTouchStart={this.handleOnTouchStart}
       >
         {this.props.playing ? <Pause /> : <Play />}
       </button>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR is another attempt to address https://github.com/freeCodeCamp/freeCodeCamp/issues/41070. We initially used `onTouchStart` but had an issue in Android, and worked around by switching to `onTouchEnd` (https://github.com/freeCodeCamp/coderadio-client/pull/98).

I'm not sure about the Android issue there, but it could be because our button was still a div and behaved differently from an actual `<button>`. Now that we have changed the element, I'm restoring the touch start event in hope that it will fix the iOS issue. 

However, I need your help with testing on an iOS device as I don't own one, but I will do a quick regression test myself on my Android device to ensure the old bug doesn't come back.

<!-- Feel free to add any additional description of changes below this line -->
