### PR TITLE
fix: pause button on iOS devices

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -3,6 +3,7 @@ import NchanSubscriber from 'nchan';
 import { GlobalHotKeys } from 'react-hotkeys';
 import * as Sentry from '@sentry/react';
 import store from 'store';
+import { isIOS } from 'react-device-detect';
 
 import Nav from './Nav';
 import Main from './Main';
@@ -230,7 +231,7 @@ export default class App extends React.Component {
       }
       // If it is already playing, fade the music out (resulting in a pause)
       else {
-        this.fade();
+        this.fadeDown();
       }
     }
   }
@@ -256,7 +257,7 @@ export default class App extends React.Component {
    * Simple fade command to initiate the playing and pausing
    * in a more fluid method.
    */
-  fade(direction = 'down') {
+  fade(direction) {
     let audioConfig = { ...this.state.audioConfig };
     audioConfig.targetVolume =
       direction.toLowerCase() === 'up' ? this.state.audioConfig.maxVolume : 0;
@@ -287,8 +288,14 @@ export default class App extends React.Component {
      * we set the toFixed in order to avoid 0.999999999999 increments.
      */
     let currentVolume = parseFloat(this._player.volume.toFixed(2));
-    // If the volume is correctly set to the target, no need to change it
-    if (currentVolume === this.state.audioConfig.targetVolume) {
+    /**
+     * If the volume is correctly set to the target, no need to change it
+     *
+     * Note: On iOS devices, volume level is totally under user's control and cannot be programmatically set.
+     * We pause the music immediately in this case.
+     * (https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/Device-SpecificConsiderations/Device-SpecificConsiderations.html)
+     */
+    if (currentVolume === this.state.audioConfig.targetVolume || isIOS) {
       // If the audio is set to 0 and it’s been met, pause the audio
       if (this.state.audioConfig.targetVolume === 0 && this.state.pausing)
         this.pause();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

When the user clicks the pause button, we gradually fade the music down and only pause the player if the current volume is set to 0. 

A special thing about iOS devices is that they don't allow volume to be programmatically set, and the volume value is always 1. This means it will never get back to 0, thus never triggers the `pause` function.

> On the desktop, you can set and read the volume property of an <audio> or <video> element. This allows you to set the element’s audio volume relative to the computer’s current volume setting. A value of 1 plays sound at the normal level. A value of 0 silences the audio. Values between 0 and 1 attenuate the audio.
> 
> This volume adjustment can be useful, because it allows the user to mute a game, for example, while still listening to music on the computer.
>
> On iOS devices, the audio level is always under the user’s physical control. The volume property is not settable in JavaScript. Reading the volume property always returns 1.

Ref: https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/Device-SpecificConsiderations/Device-SpecificConsiderations.html

---

I tested the changes on iOS devices using BrowserStack.

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/41070 (third time's the charm)

<!-- Feel free to add any additional description of changes below this line -->
