### PR TITLE
fix: typos in function name (stopCurrenttInterval and toggleIntterval) in footer.js

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -35,9 +35,9 @@ export default class Footer extends React.PureComponent {
         currentSong: this.props.currentSong,
         alternativeMounts: [].concat(this.props.remotes, this.props.mounts)
       });
-      this.toggleIntterval();
+      this.toggleInterval();
     } else if (prevProps.playing !== this.props.playing) {
-      this.toggleIntterval();
+      this.toggleInterval();
     }
   }
 

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -42,7 +42,7 @@ export default class Footer extends React.PureComponent {
   }
 
   startInterval() {
-    this.stopCurrenttInterval();
+    this.stopCurrentInterval();
     this.setState({
       progressInterval: setInterval(this.updateProgress, 100)
     });
@@ -56,7 +56,7 @@ export default class Footer extends React.PureComponent {
 
   toggleInterval() {
     if (this.props.playing && this.state.isTabVisible) this.startInterval();
-    else this.stopCurrenttInterval();
+    else this.stopCurrentInterval();
   }
 
   updateProgress() {

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -48,13 +48,13 @@ export default class Footer extends React.PureComponent {
     });
   }
 
-  stopCurrenttInterval() {
+  stopCurrentInterval() {
     if (this.state.progressInterval) {
       clearInterval(this.state.progressInterval);
     }
   }
 
-  toggleIntterval() {
+  toggleInterval() {
     if (this.props.playing && this.state.isTabVisible) this.startInterval();
     else this.stopCurrenttInterval();
   }

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -74,7 +74,7 @@ export default class Footer extends React.PureComponent {
 
   handleVisibilityChange = isTabVisible => {
     this.setState({ isTabVisible }, () => {
-      this.toggleIntterval();
+      this.toggleInterval();
     });
   };
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the 43102 below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/43102

<!-- Feel free to add any additional description of changes below this line -->
There were some typos in the function name in the Code Radio app:  stopCurrenttInterval and toggleIntterval.

I have changed stopCurrenttInterval to stopCurrentInterval, and toggleIntterval to toggleInterval .
Changes are made according to issue #43102.
