### PR TITLE
Made the background more responsive.

### DIFF
--- a/src/css/App.css
+++ b/src/css/App.css
@@ -52,25 +52,16 @@ p {
 
 @media only screen and (min-width: 768px) {
   .animation {
-    background-image: url('https://cdn-media-1.freecodecamp.org/code-radio/bg.jpg');
+    background-image: url("../assets/bg.gif");
     background-position: left bottom;
+    background-size: cover;
     background-repeat: no-repeat;
     display: block;
-    height: calc(100% - 158px);
-    margin-top: 88px;
+    margin-top: -68px;
     position: relative;
     width: 100%;
+    height: 100%;
   }
-}
-
-.animation::before {
-  background-image: url('https://cdn-media-1.freecodecamp.org/code-radio/Saron3.gif');
-  bottom: 0;
-  content: '';
-  height: 767px;
-  left: 388px;
-  position: absolute;
-  width: 509px;
 }
 
 .site-title {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/41072

<!-- Feel free to add any additional description of changes below this line -->

User stories

- [x] Users should see as much of the image as possible.
- [x]   If the view has a wider ratio in comparison to the image, the image's full width should be displayed allowing the upper and lower part of the image to stay outside of the screen.
- [x]   If the view has a taller ratio in comparison to the image, the image's full height should be displayed allowing the the sides of the image to be out of the view.
- [x]   It would be great if we could achieve this without using js.

***
### Details about the fix

- Removed the `.animation::before` pseudo element.
- Exported a new background gif by overlaying the animation and static image together.
- Used the new `bg.gif` as the background.
- Adjusted the css properties to make the gif responsive.
***

### Assets added
- bg.gif

![bg](https://user-images.githubusercontent.com/63310399/135718778-de12d99e-c876-4b63-bbef-e75f3ff8a3a2.gif)

