### PR TITLE
Remove react-hotkeys dependency in favor of native handling solution

### DIFF
--- a/cypress/integration/play-button.js
+++ b/cypress/integration/play-button.js
@@ -10,7 +10,7 @@ describe('Stop and play the music', () => {
       .invoke('attr', 'src')
       .should('contain', 'freecodecamp.org/radio')
       .then(() => {
-        cy.get('#playContainer')
+        cy.get('#toggle-play-pause')
           .should('be.visible')
           .click();
         cy.get('audio').should(audioElements => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14736,11 +14736,11 @@
       }
     },
     "react-device-detect": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-1.17.0.tgz",
-      "integrity": "sha512-bBblIStwpHmoS281JFIVqeimcN3LhpoP5YKDWzxQdBIUP8S2xPvHDgizLDhUq2ScguLfVPmwfF5y268EEQR60w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.1.2.tgz",
+      "integrity": "sha512-N42xttwez3ECgu4KpOL2ICesdfoz8NCBfmc1rH9FRYSjH7NmMyANPSrQ3EvAtJyj/6TzJNhrANSO38iXjCB2Ug==",
       "requires": {
-        "ua-parser-js": "^0.7.24"
+        "ua-parser-js": "^0.7.30"
       }
     },
     "react-dom": {
@@ -14758,14 +14758,6 @@
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
-    },
-    "react-hotkeys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-hotkeys/-/react-hotkeys-2.0.0.tgz",
-      "integrity": "sha512-3n3OU8vLX/pfcJrR3xJ1zlww6KS1kEJt0Whxc4FiGV+MJrQ1mYSYI3qS/11d2MJDFm8IhOXMTFQirfu6AVOF6Q==",
-      "requires": {
-        "prop-types": "^15.6.1"
-      }
     },
     "react-is": {
       "version": "16.13.1",
@@ -17214,9 +17206,9 @@
       }
     },
     "ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
+      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@sentry/tracing": "5.30.0",
     "nchan": "1.0.10",
     "react": "16.14.0",
-    "react-device-detect": "1.17.0",
+    "react-device-detect": "2.1.2",
     "react-dom": "16.14.0",
     "react-page-visibility": "6.4.0",
     "react-scripts": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "react": "16.14.0",
     "react-device-detect": "1.17.0",
     "react-dom": "16.14.0",
-    "react-hotkeys": "2.0.0",
     "react-page-visibility": "6.4.0",
     "react-scripts": "4.0.3",
     "store": "2.0.12"

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -107,12 +107,12 @@ export default class App extends React.Component {
     this.handleKeyboardHotKeys = this.handleKeyboardHotKeys.bind(this);
   }
 
-  isToggleHotKey(event) {
-    return [' '].includes(event.key);
+  isSpacePressed(event) {
+    return event.key === ' ';
   }
 
   canTogglePlayPause(event) {
-    // List of elements to do not allow toogle play/pause when pressing space or "k"
+    // Prevent play/pause toggle when elements with ids in the following list are pressed.
     const disallowedIds = [
       'recent-song-history',
       'toggle-play-pause',
@@ -130,7 +130,7 @@ export default class App extends React.Component {
     keyMap.set('ArrowUp', this.increaseVolume);
     keyMap.set('ArrowDown', this.decreaseVolume);
 
-    if (this.isToggleHotKey(event) && !this.canTogglePlayPause(event)) return;
+    if (this.isSpacePressed(event) && !this.canTogglePlayPause(event)) return;
 
     const callback = keyMap.get(event.key);
     if (!callback || typeof callback !== 'function') {

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -86,6 +86,7 @@ export default class Footer extends React.PureComponent {
         <select
           aria-label='Select Stream'
           data-meta='stream-select'
+          id='stream-select'
           onChange={this.handleChange.bind(this)}
           value={this.props.url}
         >

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -16,7 +16,7 @@ const Main = props => {
           <div className='animation' />
           <Visualizer player={props.player} playing={props.playing} />
           <details>
-            <summary>Keyboard Controls</summary>
+            <summary id='keyboard-controls'>Keyboard Controls</summary>
             <dl>
               <dt>Play/Pause:</dt>
               <dd>Spacebar or "k"</dd>

--- a/src/components/PlayPauseButton.js
+++ b/src/components/PlayPauseButton.js
@@ -41,7 +41,7 @@ class PlayPauseButton extends React.Component {
             ? 'play-container-cta play-container'
             : 'play-container'
         }
-        id='playContainer'
+        id='toggle-play-pause'
         onClick={this.handleOnClick}
         onKeyDown={this.handleKeyDown}
         onTouchEnd={this.handleOnTouchEnd}

--- a/src/components/SongHistory.js
+++ b/src/components/SongHistory.js
@@ -27,6 +27,7 @@ class SongHistory extends Component {
       <button
         aria-label='Recent Song History'
         className='recent-song-history'
+        id='recent-song-history'
         onClick={this.toggleDisplay}
       >
         {this.state.displayList && (


### PR DESCRIPTION
Checklist:
- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/43098

It replaces the `react-hotkeys` dependency with native handling by listening to `keydown` events and the shortcuts are only available if the device is a browser (done by `react-device-detect` dependency).

Also fixed the bug when pressing space in a component that should relay on its own context instead of toggling play/pause. The solution was to create a disallow list to do not perform `tooglePlay` function if the focus is on components like Recent Song History.