### PR TITLE
perf: Update logo html height and width to what's effectively done via css

### DIFF
--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -20,7 +20,9 @@ export default function Nav() {
         <a className='site-nav-logo' href='https://coderadio.freecodecamp.org/'>
           <img
             alt='Code Radio'
+            height='25'
             src='https://cdn.freecodecamp.org/platform/universal/fcc_primary.svg'
+            width='218.75'
           />
         </a>
       </div>

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -599,9 +599,7 @@ footer {
 
 .site-nav-logo img {
   display: block;
-  height: 25px;
   margin-top: 7px;
-  width: auto;
 }
 
 .site-nav-right {


### PR DESCRIPTION
Follows lighthouse guidelines on cumulative layout shift and removes warning. I noticed that the height and width was effectively always this fixed height and width at all breakpoints with the previous css solution.

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

## before

- image height and width warning 
<img width="1415" alt="Screen Shot 2021-10-26 at 10 09 00 PM" src="https://user-images.githubusercontent.com/5950956/138993510-4b137913-087b-4096-8451-87adcf7c653a.png">

## after

- no image height and width warning
<img width="1326" alt="Screen Shot 2021-10-26 at 10 10 36 PM" src="https://user-images.githubusercontent.com/5950956/138993580-affc1a9b-b24b-479b-b164-f28ccefd501a.png">


# dependencies 

- Would likely want to change this for all over fCC if wanted


Would appreciate it if this was labelled for hacktoberfest: 

```
A pull request is considered approved once it has an overall approving review from maintainers, or has been merged by maintainers, or has been given the 'hacktoberfest-accepted' label.*


