### PR TITLE
fix: volume control accessibility

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -128,6 +128,12 @@ export default class App extends React.Component {
     return event.key === 'ArrowUp' || event.key === 'ArrowDown';
   }
 
+  canAdjustVolume() {
+    // Ignore arrow hot keys if focus is on volume slider or stream selector.
+    const disallowedIds = ['volume-input', 'stream-select'];
+    return !disallowedIds.includes(document.activeElement.id);
+  }
+
   handleKeyboardHotKeys(event) {
     const keyMap = new Map();
     keyMap.set(' ', this.togglePlay);
@@ -135,21 +141,17 @@ export default class App extends React.Component {
     keyMap.set('ArrowUp', this.increaseVolume);
     keyMap.set('ArrowDown', this.decreaseVolume);
 
+    if (!keyMap.has(event.key)) return;
+
     if (this.isSpacePressed(event) && !this.canTogglePlayPause()) return;
 
-    // Don't allow arrow hot keys to adjust volume if the volume input
-    // has focus as the volume input is already adjusting the volume.
-    if (
-      this.isUpDownArrowPressed(event) &&
-      document.activeElement.id === 'volume-input'
-    )
-      return;
+    if (this.isUpDownArrowPressed(event) && !this.canAdjustVolume()) return;
 
-    const callback = keyMap.get(event.key);
-    if (!callback || typeof callback !== 'function') {
-      return;
+    try {
+      keyMap.get(event.key)();
+    } catch (err) {
+      console.log(`Bad callback for hotkey '${event.key}': ${err.message}`);
     }
-    callback();
   }
 
   addKeyboardHotKeysListener() {

--- a/src/components/PlayPauseButton.js
+++ b/src/components/PlayPauseButton.js
@@ -14,16 +14,6 @@ class PlayPauseButton extends React.Component {
 
   handleOnTouchEnd = () => !isBrowser && this.props.togglePlay();
 
-  handleKeyDown = event => {
-    /**
-     * Toggle play when user presses Enter.
-     * The Space keypress event is ignored to avoid collision with the GlobalHotKeys.
-     */
-    if (event.keyCode === 13) {
-      this.handleOnClick();
-    }
-  };
-
   static getDerivedStateFromProps(nextProps, prevState) {
     // Set initial load to render the initial message accordingly
     if (prevState.initialLoad && nextProps.playing) {
@@ -43,7 +33,6 @@ class PlayPauseButton extends React.Component {
         }
         id='toggle-play-pause'
         onClick={this.handleOnClick}
-        onKeyDown={this.handleKeyDown}
         onTouchEnd={this.handleOnTouchEnd}
       >
         {this.props.playing ? <Pause /> : <Play />}

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const MAX = 100;
+const STEP = 5;
 
 const Slider = ({ currentVolume, setTargetVolume }) => {
   const handleChange = event => {
@@ -14,11 +15,12 @@ const Slider = ({ currentVolume, setTargetVolume }) => {
   return (
     <div className='slider-container'>
       <input
-        aria-label='slider'
+        aria-label='volume'
         className='slider'
         max={MAX}
         min='0'
         onChange={handleChange}
+        step={STEP}
         type='range'
         value={sliderVal}
       />

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -17,6 +17,7 @@ const Slider = ({ currentVolume, setTargetVolume }) => {
       <input
         aria-label='volume'
         className='slider'
+        id='volume-input'
         max={MAX}
         min='0'
         onChange={handleChange}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Label on the volume control should be "volume" instead of "slider".

I added a step of 5 to the slider which gives the user 21 distinct volume levels to choose from. Giving them 101 seemed excessive, especially for keyboard users.