### PR TITLE
fix: hide progress bar from accessibility tree

### DIFF
--- a/src/components/CurrentSong.js
+++ b/src/components/CurrentSong.js
@@ -20,6 +20,7 @@ const CurrentSong = props => (
     <div className='now-playing'>
       <div className='progress-container'>
         <progress
+          aria-hidden='true'
           data-meta='duration'
           max={props.songDuration}
           value={props.progressVal}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The trouble with the progress bar is that most screen readers will continually announce intermittent updates on the current value of the bar, or emit a beep every few seconds to alert the user that progress is still being made, which can be quite annoying when you are trying to listen to the music. So I have removed the progress bar from the accessibility tree to solve this issue. The next step is to come up with an alternative method to allow AT users a way to see how much time is left on the current song.