### PR TITLE
UX for slider when volume is less than 5

### DIFF
--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -7,8 +7,31 @@ const STEP = 5;
 const Slider = ({ currentVolume, setTargetVolume }) => {
   const handleChange = event => {
     let { value } = event.target;
-    setTargetVolume(value / MAX);
+    if (value >= 5) {
+      setTargetVolume(Math.floor(value / MAX));
+    } else {
+      setTargetVolume(value / MAX);
+    }
   };
+
+  const sliderVal = currentVolume * MAX;
+
+  return (
+    <div className='slider-container'>
+      <input
+        aria-label='volume'
+        className='slider'
+        id='volume-input'
+        max={MAX}
+        min='0'
+        onChange={handleChange}
+        step={STEP}
+        type='range'
+        value={sliderVal}
+      />
+    </div>
+  );
+};
 
   const sliderVal = currentVolume * MAX;
 


### PR DESCRIPTION
This change allows to reduce the value in steps of 1 when the volume we want is less than 5

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
