### PR TITLE
fix: change default port to 3001

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           browser: ${{ matrix.browsers }}
           build: npm run build
           start: npm start
-          wait-on: http://localhost:3000
+          wait-on: http://localhost:3001
           wait-on-timeout: 1200
 
   unit-test:

--- a/cypress/integration/home.js
+++ b/cypress/integration/home.js
@@ -1,7 +1,7 @@
 /* global cy */
 describe('Landing page', () => {
   it('Should render', () => {
-    cy.visit('http://localhost:3000');
+    cy.visit('http://localhost:3001');
     cy.title().should('eq', 'freeCodeCamp.org Code Radio');
   });
 });

--- a/cypress/integration/play-button.js
+++ b/cypress/integration/play-button.js
@@ -1,6 +1,6 @@
 describe('Stop and play the music', () => {
   beforeEach(() => {
-    cy.visit('http://localhost:3000');
+    cy.visit('http://localhost:3001');
   });
 
   it('Click play button', () => {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "store": "2.0.12"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "PORT=3001 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --watchAll=false",
     "test:watch": "react-scripts test",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR changes the default localhost port from 3000 to 3001. It's so that the port doesn't collide with the main repo's server port (I was running both repos at the same time and got a funny issue where the /learn client was sending me to code radio rather than logging me in).

<!-- Feel free to add any additional description of changes below this line -->
